### PR TITLE
Remove broken link

### DIFF
--- a/website/jdcloud.erb
+++ b/website/jdcloud.erb
@@ -23,9 +23,6 @@
                 <li<%= sidebar_current("docs-jdcloud-availability-group") %>>
                     <a href="/docs/providers/jdcloud/jdcloud_availability_group.html">jdcloud_availability_group</a>
                 </li>
-                <li<%= sidebar_current("docs-jdcloud-ag-instance") %>>
-                    <a href="/docs/providers/jdcloud/jdcloud_ag_instance.html">jdcloud_ag_instance</a>
-                </li>
                 <li<%= sidebar_current("docs-alicloud-resource-disk") %>>
                     <a href="/docs/providers/jdcloud/jdcloud_disk.html">jdcloud_disk</a>
                 </li>


### PR DESCRIPTION
Remove the jdcloud_ag_instance.html link because it is no longer pointing to anything.