### PR TITLE
Tweak CI and GNUmakefile to better fit go modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,17 +6,19 @@ language: go
 go:
   - "1.12"
 
+env:
+  global:
+    - GOFLAGS=-mod=vendor GO111MODULE=on
+
 install:
 # This script is used by the Travis build to install a cookie for
 # go.googlesource.com so rate limits are higher when using `go get` to fetch
 # packages that live there.
 # See: https://github.com/golang/go/issues/12933
 - bash scripts/gogetcookie.sh
-- go get github.com/kardianos/govendor
 
 script:
 - make test
-- make vendor-status
 - make vet
 - CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o terraform-provider-jdcloud
 - tar zcvf Linux-amd64.tar.gz terraform-provider-jdcloud

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -28,11 +28,7 @@ fmtcheck:
 errcheck:
 	@sh -c "'$(CURDIR)/scripts/errcheck.sh'"
 
-vendor-status:
-	@govendor status
-
 tools:
-	go get -u github.com/kardianos/govendor
 	go get -u github.com/alecthomas/gometalinter
 	gometalinter --install
 


### PR DESCRIPTION
Signed-off-by: imjoey <majunjiev@gmail.com>

Changes proposed in this pull request:
* Add global GOFLAGS `-mod=verdor GO111MODULE=on` to force go commands to use packages in `./vendor` directory
* Obsolete `govendor` package and command after go modules has been enabled

I also notice that there is a replace section defined in `go.mod`:
`replace github.com/jdcloud-api/jdcloud-sdk-go => ./vendor/github.com/jdcloud-api/jdcloud-sdk-go`.
I'm a little confused about what the purpose is? Does it mean to force use specific package in ./vendor instead of in GOPATH? Thanks for your time.