### PR TITLE
docs: Formalize inline HCL codes to canonical format

### DIFF
--- a/website/docs/jdcloud_availability_group.html.markdown
+++ b/website/docs/jdcloud_availability_group.html.markdown
@@ -15,10 +15,10 @@ Provides a JDCloud Availability Group
 ```hcl
 resource "jdcloud_availability_group" "ag_01" {
   availability_group_name = "example_ag_name"
-  az = ["cn-north-1a","cn-north-1b"]
-  instance_template_id = "example_template_id"
-  description  = "This is an example description"
-  ag_type = "docker"
+  az                      = ["cn-north-1a", "cn-north-1b"]
+  instance_template_id    = "example_template_id"
+  description             = "This is an example description"
+  ag_type                 = "docker"
 }
 ```
 

--- a/website/docs/jdcloud_disk_attachment.html.markdown
+++ b/website/docs/jdcloud_disk_attachment.html.markdown
@@ -13,9 +13,9 @@ After a disk has been created, you probably need to attach it to an instance
 ### Example Usage 
 
 ```hcl
-resource "jdcloud_disk_attachment" "disk-attachment-example"{
+resource "jdcloud_disk_attachment" "disk-attachment-example" {
   instance_id = "i-example"
-  disk_id = "vol-example"
+  disk_id     = "vol-example"
 }
 ```
 

--- a/website/docs/jdcloud_eip.html.markdown
+++ b/website/docs/jdcloud_eip.html.markdown
@@ -13,8 +13,8 @@ Provides a JDCloud elastic IP address
 ### Example Usage 
 
 ```hcl
-resource "jdcloud_eip" "example"{
-  eip_provider = "bgp"
+resource "jdcloud_eip" "example" {
+  eip_provider   = "bgp"
   bandwidth_mbps = 1
 }
 ```

--- a/website/docs/jdcloud_eip_association.html.markdown
+++ b/website/docs/jdcloud_eip_association.html.markdown
@@ -13,8 +13,8 @@ After you have created an EIP, you can attach this EIP with an instance
 ### Example Usage
 
 ```hcl
-resource "jdcloud_eip_association" "eip-association-example"{
-  instance_id = "i-example"
+resource "jdcloud_eip_association" "eip-association-example" {
+  instance_id   = "i-example"
   elastic_ip_id = "fip-example"
 }
 ```

--- a/website/docs/jdcloud_network_interface.html.markdown
+++ b/website/docs/jdcloud_network_interface.html.markdown
@@ -14,7 +14,7 @@ Provides a JDCloud network interface
 
 ```hcl
 resource "jdcloud_network_interface" "example-ineterface" {
-  subnet_id = "subnet-example"
+  subnet_id              = "subnet-example"
   network_interface_name = "example"
 }
 ```

--- a/website/docs/jdcloud_network_interface_attachment.html.markdown
+++ b/website/docs/jdcloud_network_interface_attachment.html.markdown
@@ -13,8 +13,8 @@ After you have created network interface, you can attach this network interface 
 ### Example Usage 
 
 ```hcl
-resource "jdcloud_network_interface_attachment" "attachment-example"{
-  instance_id = "i-example"
+resource "jdcloud_network_interface_attachment" "attachment-example" {
+  instance_id          = "i-example"
   network_interface_id = "port-example"
 }
 ```

--- a/website/docs/jdcloud_network_security_group.html.markdown
+++ b/website/docs/jdcloud_network_security_group.html.markdown
@@ -15,7 +15,7 @@ Provides a JDCloud network security group
 ```hcl
 resource "jdcloud_network_security_group" "sg-example" {
   network_security_group_name = "sg-example"
-  vpc_id = "vpc-example"
+  vpc_id                      = "vpc-example"
 }
 ```
 

--- a/website/docs/jdcloud_oss_bucket_upload.html.markdown
+++ b/website/docs/jdcloud_oss_bucket_upload.html.markdown
@@ -17,7 +17,7 @@ After the OSS bucket has been created, you can upload file to this OSS bucket
 ```hcl
 resource "jdcloud_oss_bucket_upload" "example" {
   bucket_name = "bucket_example"
-  file_name = "/path/to/file"
+  file_name   = "/path/to/file"
 }
 ```
 

--- a/website/docs/jdcloud_rds_account.html.markdown
+++ b/website/docs/jdcloud_rds_account.html.markdown
@@ -12,10 +12,10 @@ Set up users for each RDS instance
 ### Example Usage
 
 ```hcl
-resource "jdcloud_rds_account" "account_example"{
+resource "jdcloud_rds_account" "account_example" {
   instance_id = "mysql-example"
-  username = "example"
-  password = "example2018"
+  username    = "example"
+  password    = "example2018"
 }
 ```
 

--- a/website/docs/jdcloud_rds_database.html.markdown
+++ b/website/docs/jdcloud_rds_database.html.markdown
@@ -11,9 +11,9 @@ description: |-
 After a RDS instance has been created, you probably need to create some databases on this instance
 
 ```hcl
-resource "jdcloud_rds_database" "db-example"{
-  instance_id = "mysql-example"
-  db_name = " example"
+resource "jdcloud_rds_database" "db-example" {
+  instance_id   = "mysql-example"
+  db_name       = " example"
   character_set = "utf8"
 }
 ```

--- a/website/docs/jdcloud_rds_instance.html.markdown
+++ b/website/docs/jdcloud_rds_instance.html.markdown
@@ -13,16 +13,16 @@ Provides a JDCloud RDS instance.
 ### Example Usage
 
 ```hcl
-resource "jdcloud_rds_instance" "rds_example"{
-  instance_name = "example"
-  engine = "MySQL"
-  engine_version = "5.7"
-  instance_class = "db.mysql.s1.micro"
+resource "jdcloud_rds_instance" "rds_example" {
+  instance_name       = "example"
+  engine              = "MySQL"
+  engine_version      = "5.7"
+  instance_class      = "db.mysql.s1.micro"
   instance_storage_gb = "20"
-  az = "cn-north-1a"
-  vpc_id = "vpc-example"
-  subnet_id = "subnet-example"
-  charge_mode = "postpaid_by_usage"
+  az                  = "cn-north-1a"
+  vpc_id              = "vpc-example"
+  subnet_id           = "subnet-example"
+  charge_mode         = "postpaid_by_usage"
 }
 ```
 

--- a/website/docs/jdcloud_rds_privilege.html.markdown
+++ b/website/docs/jdcloud_rds_privilege.html.markdown
@@ -14,12 +14,12 @@ Assign privileges to each account
 ```hcl
 resource "jdcloud_rds_privilege" "pri-example" {
   instance_id = "mysql-example"
-  username = "example"
+  username    = "example"
   account_privilege = [
-  
-    {db_name = "db1",privilege = "rw"},
-    {db_name = "db2",privilege = "ro"},
-    
+
+    { db_name = "db1", privilege = "rw" },
+    { db_name = "db2", privilege = "ro" },
+
   ]
 }
 ```

--- a/website/docs/jdcloud_route_table.html.markdown
+++ b/website/docs/jdcloud_route_table.html.markdown
@@ -13,7 +13,7 @@ Provides a JDCloud route table
 
 ```hcl
 resource "jdcloud_route_table" "example" {
-  vpc_id = "vpc-example"
+  vpc_id           = "vpc-example"
   route_table_name = "example"
 }
 ```

--- a/website/docs/jdcloud_route_table_rules.html.markdown
+++ b/website/docs/jdcloud_route_table_rules.html.markdown
@@ -13,21 +13,21 @@ After a route table is created, you probably need to add some routing rules to t
 ### Example Usage
 
 ```hcl
-resource "jdcloud_route_table_rules" "rule-example"{
+resource "jdcloud_route_table_rules" "rule-example" {
   route_table_id = "rtb-example"
   rule_specs = [
 
     {
-      next_hop_type = "internet"
-      next_hop_id   = "internet"
-      address_prefix= "10.0.0.0/16"
+      next_hop_type  = "internet"
+      next_hop_id    = "internet"
+      address_prefix = "10.0.0.0/16"
     },
 
     {
-      next_hop_type = "instance"
-      next_hop_id   = "i-example"
-      address_prefix= "10.0.2.0/16"
-    }]
+      next_hop_type  = "instance"
+      next_hop_id    = "i-example"
+      address_prefix = "10.0.2.0/16"
+  }]
 
 }
 ```

--- a/website/docs/jdcloud_subnet.html.markdown
+++ b/website/docs/jdcloud_subnet.html.markdown
@@ -13,10 +13,10 @@ Provides a JDCloud subnet
 ### Example Usage 
 
 ```hcl
-resource "jdcloud_subnet" "subnet-exmaple"{
-	vpc_id = "vpc-example"
-	cidr_block = "10.0.128.0/24"
-	subnet_name = "example"
+resource "jdcloud_subnet" "subnet-exmaple" {
+  vpc_id      = "vpc-example"
+  cidr_block  = "10.0.128.0/24"
+  subnet_name = "example"
 }
 ```
 

--- a/website/docs/jdcloud_vpc.html.markdown
+++ b/website/docs/jdcloud_vpc.html.markdown
@@ -13,9 +13,9 @@ Provides a JDCloud VPC
 ### Example Usage
 
 ```hcl
-resource "jdcloud_vpc" "vpc-example"{
-	vpc_name = "example"
-	cidr_block = "172.16.0.0/19"
+resource "jdcloud_vpc" "vpc-example" {
+  vpc_name   = "example"
+  cidr_block = "172.16.0.0/19"
 }
 ```
 


### PR DESCRIPTION
Along with the release of Terraform v0.12, Terraform also introduces the officially recommended [Idiomatic Style Conventions](https://www.terraform.io/docs/configuration/style.html) for HCL languages. For better readability of the docs, the inline HCLs in docs should also follow that rule. 

This PR is trying to convert all the existing inline HCL codes into the canonical format. The overall formatting process is done by a tool I developed.

Signed-off-by: imjoey <majunjiev@gmail.com>
